### PR TITLE
Misleading Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,12 +127,12 @@ Having such set of rules we can do some reasoning:
 0.4
 >>>
 >>> candidates = {
-...     "car1": {"horsepower": 70, "production_year": 2012, "price": 15000},
-...     "car2": {"horsepower": 150, "production_year": 2010, "price": 30000},
-...     "car3": {"horsepower": 90, "production_year": 2014, "price": 10000},
-...     "car4": {"horsepower": 85, "production_year": 2009, "price": 35000},
-... }
->>> max(candidates.iteritems(), key=lambda (key, inputs): is_hot.eval(**inputs))
+    "car1": {"horsepower": 70, "production_year": 2012, "price": 15000},
+    "car2": {"horsepower": 150, "production_year": 2010, "price": 30000},
+    "car3": {"horsepower": 90, "production_year": 2014, "price": 10000},
+    "car4": {"horsepower": 85, "production_year": 2009, "price": 35000}
+    }
+>>> max(candidates.iteritems(), key=lambda (key, inputs): should_buy.eval(**inputs))
 ('car3', {'horsepower': 90, 'price': 10000, 'production_year': 2014})
 ```
 


### PR DESCRIPTION
It seems that while writing the README, (arguably the most important file of all open-source projects) you've slipped and used the wrong rule. 

If one attempts to run the proposed example code, they would be greeted with "NameError: global name 'is_hot' is not defined".
I fix that by renaming it to the correct "should_buy".

Also, I would mention somewhere that to use the lambda expression, one must use python2. The "max(candidates.iteritems(), key=lambda (key, inputs): should_buy.eval(**inputs))" will throw a syntax error in python3.

I've also removed the dots from the dictionary example, to enable easier copy-paste while testing the example.

I hope this helps all the people looking to get started with fuzzy sets!